### PR TITLE
fix(battery.js): change order of battery loading to suppress warning

### DIFF
--- a/battery.js
+++ b/battery.js
@@ -9,7 +9,7 @@
  */
 var Battery = (function(self) {
   var _events = 'chargingchange chargingtimechange dischargingtimechange levelchange'
-    , _battery = navigator.battery || navigator.mozBattery || navigator.getBattery
+    , _battery = navigator.getBattery || navigator.battery || navigator.mozBattery
     , _status = null
     , _statusCallback = function() {}
     , _updateCallback = function() {}


### PR DESCRIPTION
`navigator.battery` will be deprecated in Firefox 50. Firefox 49 shows a warning in the console:
![screen shot 2016-09-27 at 13 44 37](https://cloud.githubusercontent.com/assets/617198/18891311/8e62021e-84b9-11e6-92c7-f44b47723cc2.png)

Changing the order to suppress the warning.
